### PR TITLE
Fixed Openshift cleanup sequence

### DIFF
--- a/app-onboard/README.adoc
+++ b/app-onboard/README.adoc
@@ -244,7 +244,7 @@ Finishing up any deployments and any additional objects created can be deleted u
 oc delete deploymentconfig sample-camel; \
 oc delete service sample-camel; \
 oc delete pvc keepme; \
-oc delete ingress sample-camel
+oc delete route sample-camel
 ----
 
 

--- a/app-onboard/sample-camel-spring-boot/pom.xml
+++ b/app-onboard/sample-camel-spring-boot/pom.xml
@@ -27,7 +27,7 @@
         <!-- jkube settings -->
         <jkube-maven-plugin.version>1.17.0</jkube-maven-plugin.version>
 
-        <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:1.20-2.1726695177</jkube.generator.from>
+        <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:1.20-2.1729773462</jkube.generator.from>
         <!-- <jkube.docker.push.registry>quay.io/erouvas</jkube.docker.push.registry>
         <jkube.docker.pull.registry>quay.io/erouvas</jkube.docker.pull.registry> -->
         <jkube.imagePullPolicy>Always</jkube.imagePullPolicy>


### PR DESCRIPTION
The cleanup sequence in the documentation was wrong. Not all objects were deleted.
This PR fixes that, substitutes "route" for "ingress" in the cleanup instructions